### PR TITLE
Use Juvix binary directly from release archive.

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -7,33 +7,6 @@ jobs:
       - name: Checkout our repository
         uses: actions/checkout@v3
 
-      - name: Cache LLVM and Clang
-        id: cache-llvm
-        uses: actions/cache@v3
-        with:
-          path: |
-            C:/Program Files/LLVM
-            ./llvm
-          key: "${{ runner.os }}-llvm-13"
-
-      - name: Install LLVM and Clang
-        uses: KyleMayes/install-llvm-action@v1
-        with:
-          version: "13.0"
-          cached: "${{ steps.cache-llvm.outputs.cache-hit }}"
-
-      - name: Download and extract wasi-sysroot
-        run: |
-          curl https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-15/wasi-sysroot-15.0.tar.gz -OL
-          tar xfv wasi-sysroot-15.0.tar.gz
-      - name: Set WASI_SYSROOT_PATH
-        run: |
-          echo "WASI_SYSROOT_PATH=$GITHUB_WORKSPACE/wasi-sysroot" >> $GITHUB_ENV
-
-      - name: Install libtinfo5
-        run: |
-          sudo apt install libtinfo5
-
       - name: Install the latest Juvix compiler
         uses: jaxxstorm/action-install-gh-release@v1.10.0
         with:
@@ -43,6 +16,5 @@ jobs:
 
       - name: run quickcheck example
         run: |
-          juvix-linux_x86_64-v0.3.2 --version
-          sudo cp `which juvix-linux_x86_64-v0.3.2` /usr/bin/juvix
+          juvix --version
           make run-quickcheck


### PR DESCRIPTION
We can use the version of clang installed on the agent because the quickcheck build does not use WASI.

For the same reason we do not need the WASI sysroot.