### PR TITLE
Update to use the trait framework

### DIFF
--- a/Data/Debug.juvix
+++ b/Data/Debug.juvix
@@ -1,5 +1,4 @@
 module Data.Debug;
 
 terminating
-undefined : {A : Type} -> A;
-undefined := undefined;
+undefined : {A : Type} -> A := undefined;

--- a/Data/Function.juvix
+++ b/Data/Function.juvix
@@ -2,21 +2,21 @@ module Data.Function;
 
 import Stdlib.Prelude open;
 
-uncurry :
-  {A : Type}
+uncurry
+  : {A : Type}
     -> {B : Type}
     -> {C : Type}
     -> (A -> B -> C)
     -> A × B
-    -> C;
-uncurry f (a, b) := f a b;
+    -> C
+  | f (a, b) := f a b;
 
-curry :
-  {A : Type}
+curry
+  : {A : Type}
     -> {B : Type}
     -> {C : Type}
     -> (A × B -> C)
     -> A
     -> B
-    -> C;
-curry f a b := f (a, b);
+    -> C
+  | f a b := f (a, b);

--- a/Data/Int.juvix
+++ b/Data/Int.juvix
@@ -4,10 +4,10 @@ import Stdlib.Prelude open hiding {mod};
 import Stdlib.Data.Int.Ord open;
 import Stdlib.Data.Int open;
 
-gcd : Int → Int → Int;
-gcd a b :=
-  let
-    terminating
-    gcd' : Int -> Int -> Int;
-    gcd' a b := if (a == 0) b (gcd' (mod b a) a);
-  in if (a > b) (gcd' b a) (gcd' a b);
+gcd : Int → Int → Int
+  | a b :=
+    let
+      terminating
+      gcd' : Int -> Int -> Int;
+      gcd' a b := if (a == 0) b (gcd' (mod b a) a);
+    in if (a > b) (gcd' b a) (gcd' a b);

--- a/Data/Int.juvix
+++ b/Data/Int.juvix
@@ -8,6 +8,6 @@ gcd : Int → Int → Int
   | a b :=
     let
       terminating
-      gcd' : Int -> Int -> Int;
-      gcd' a b := if (a == 0) b (gcd' (mod b a) a);
+      gcd' : Int -> Int -> Int
+        | a b := if (a == 0) b (gcd' (mod b a) a);
     in if (a > b) (gcd' b a) (gcd' a b);

--- a/Data/List.juvix
+++ b/Data/List.juvix
@@ -23,7 +23,7 @@ unzipWith
 range : Nat -> List Nat
   | n := rangeStep 1 n;
 
-sortInt : List Int -> List Int := quickSort IntTraits.Ord;
+sortInt : List Int -> List Int := quickSort ordIntI;
 
 eqListInt : List Int -> List Int -> Bool
   | nil nil := true

--- a/Data/List.juvix
+++ b/Data/List.juvix
@@ -7,9 +7,9 @@ import Stdlib.Data.Int.Ord as Int;
 rangeStep : Nat -> Nat -> List Nat
   | step n :=
     let
-      go : Nat -> List Nat -> List Nat;
-      go zero xs := xs;
-      go (suc n) xs := go n (n * step :: xs);
+      go : Nat -> List Nat -> List Nat
+        | zero xs := xs
+        | (suc n) xs := go n (n * step :: xs);
     in go n nil;
 
 unzipWith

--- a/Data/List.juvix
+++ b/Data/List.juvix
@@ -4,32 +4,29 @@ import Stdlib.Prelude open;
 
 import Stdlib.Data.Int.Ord as Int;
 
-rangeStep : Nat -> Nat -> List Nat;
-rangeStep step n :=
-  let
-    go : Nat -> List Nat -> List Nat;
-    go zero xs := xs;
-    go (suc n) xs := go n (n * step :: xs);
-  in go n nil;
+rangeStep : Nat -> Nat -> List Nat
+  | step n :=
+    let
+      go : Nat -> List Nat -> List Nat;
+      go zero xs := xs;
+      go (suc n) xs := go n (n * step :: xs);
+    in go n nil;
 
-unzipWith :
-  {A : Type}
+unzipWith
+  : {A : Type}
     -> {B : Type}
     -> {C : Type}
     -> (A -> B -> C)
     -> List (A × B)
-    -> List C;
-unzipWith := map ∘ uncurry;
+    -> List C := map ∘ uncurry;
 
-range : Nat -> List Nat;
-range n := rangeStep 1 n;
+range : Nat -> List Nat
+  | n := rangeStep 1 n;
 
-sortInt : List Int -> List Int;
-sortInt := quickSort IntTraits.Ord;
+sortInt : List Int -> List Int := quickSort IntTraits.Ord;
 
-eqListInt : List Int -> List Int -> Bool;
-eqListInt nil nil := true;
-eqListInt (x :: _) nil := false;
-eqListInt nil (x :: _) := false;
-eqListInt (x :: xs) (y :: ys) :=
-  x Int.== y && eqListInt xs ys;
+eqListInt : List Int -> List Int -> Bool
+  | nil nil := true
+  | (x :: _) nil := false
+  | nil (x :: _) := false
+  | (x :: xs) (y :: ys) := x Int.== y && eqListInt xs ys;

--- a/Data/Monoid.juvix
+++ b/Data/Monoid.juvix
@@ -3,7 +3,7 @@ module Data.Monoid;
 import Stdlib.Prelude open;
 
 type Monoid (A : Type) :=
-  | monoid : A -> (A -> A -> A) -> Monoid A;
+  monoid : A -> (A -> A -> A) -> Monoid A;
 
 foldMap
   : {A : Type}

--- a/Data/Monoid.juvix
+++ b/Data/Monoid.juvix
@@ -5,18 +5,16 @@ import Stdlib.Prelude open;
 type Monoid (A : Type) :=
   | monoid : A -> (A -> A -> A) -> Monoid A;
 
-foldMap :
-  {A : Type}
+foldMap
+  : {A : Type}
     -> {M : Type}
     -> Monoid M
     -> (A -> M)
     -> List A
-    -> M;
-foldMap (monoid mempty mappend) f :=
-  foldr (mappend ∘ f) mempty;
+    -> M
+  | (monoid mempty mappend) f := foldr (mappend ∘ f) mempty;
 
-mconcat : {A : Type} -> Monoid A -> List A -> A;
-mconcat m xs := foldMap m id xs;
+mconcat : {A : Type} -> Monoid A -> List A -> A
+  | m xs := foldMap m id xs;
 
-string : Monoid String;
-string := monoid "" (++str);
+string : Monoid String := monoid "" (++str);

--- a/Data/Random.juvix
+++ b/Data/Random.juvix
@@ -13,14 +13,14 @@ import Stdlib.Data.Int.Ord as Int;
 type StdGen :=
   | stdGen : Nat -> Nat -> Nat -> StdGen;
 
-stdGenS1 : StdGen -> Nat;
-stdGenS1 (stdGen s1 _ _) := s1;
+stdGenS1 : StdGen -> Nat
+  | (stdGen s1 _ _) := s1;
 
-stdGenS2 : StdGen -> Nat;
-stdGenS2 (stdGen _ s2 _) := s2;
+stdGenS2 : StdGen -> Nat
+  | (stdGen _ s2 _) := s2;
 
-stdGenS3 : StdGen -> Nat;
-stdGenS3 (stdGen _ _ s3) := s3;
+stdGenS3 : StdGen -> Nat
+  | (stdGen _ _ s3) := s3;
 
 k1 : Nat := 32362;
 
@@ -28,110 +28,108 @@ k2 : Nat := 31726;
 
 k3 : Nat := 31656;
 
-mkStdGen : Nat -> StdGen;
-mkStdGen seed :=
-  let
-    q1 : Nat := div seed k1;
-    s1 : Nat := mod seed k1;
-    q2 : Nat := div q1 k2;
-    s2 : Nat := mod q1 k2;
-    s3 : Nat := mod q2 k3;
-  in stdGen (s1 + 1) (s2 + 1) (s3 + 1);
+mkStdGen : Nat -> StdGen
+  | seed :=
+    let
+      q1 : Nat := div seed k1;
+      s1 : Nat := mod seed k1;
+      q2 : Nat := div q1 k2;
+      s2 : Nat := mod q1 k2;
+      s3 : Nat := mod q2 k3;
+    in stdGen (s1 + 1) (s2 + 1) (s3 + 1);
 
-stdRange : Nat × Nat;
-stdRange := 1, k1;
+stdRange : Nat × Nat := 1, k1;
 
-stdNext : StdGen -> Nat × StdGen;
-stdNext (stdGen s1Nat s2Nat s3Nat) :=
-  let
-    s1 : Int := ofNat s1Nat;
-    s2 : Int := ofNat s2Nat;
-    s3 : Int := ofNat s3Nat;
-    k : Int := Int.div s1 206;
-    s1' :
-      Int := 157 Int.* (s1 Int.- k Int.* 206) Int.- k Int.* 21;
-    s1'' : Int := if (s1' Int.< 0) (s1' Int.+ 32363) s1';
-    k' : Int := Int.div s2 217;
-    s2' :
-      Int :=
-        146 Int.* (s2 Int.- k' Int.* 217) Int.- k' Int.* 45;
-    s2'' : Int := if (s2' Int.< 0) (s2' Int.+ 31727) s2';
-    k'' : Int := Int.div s3 222;
-    s3' :
-      Int :=
-        142 Int.* (s3 Int.- k' Int.* 222) Int.- k' Int.* 133;
-    s3'' : Int := if (s2' Int.< 0) (s2' Int.+ 31657) s3';
-    z : Int := s1'' Int.- s2'';
-    z' : Int := if (z Int.> 706) (z Int.- 32362) z;
-    z'' :
-      Int :=
-        if (z' Int.< 1) (z' Int.+ 32362) (Int.mod z (ofNat k1));
-  in toNat z'', stdGen (toNat s1'') (toNat s2'') (toNat s3'');
+stdNext : StdGen -> Nat × StdGen
+  | (stdGen s1Nat s2Nat s3Nat) :=
+    let
+      s1 : Int := ofNat s1Nat;
+      s2 : Int := ofNat s2Nat;
+      s3 : Int := ofNat s3Nat;
+      k : Int := Int.div s1 206;
+      s1' :
+        Int := 157 Int.* (s1 Int.- k Int.* 206) Int.- k Int.* 21;
+      s1'' : Int := if (s1' Int.< 0) (s1' Int.+ 32363) s1';
+      k' : Int := Int.div s2 217;
+      s2' :
+        Int :=
+          146 Int.* (s2 Int.- k' Int.* 217) Int.- k' Int.* 45;
+      s2'' : Int := if (s2' Int.< 0) (s2' Int.+ 31727) s2';
+      k'' : Int := Int.div s3 222;
+      s3' :
+        Int :=
+          142 Int.* (s3 Int.- k' Int.* 222) Int.- k' Int.* 133;
+      s3'' : Int := if (s2' Int.< 0) (s2' Int.+ 31657) s3';
+      z : Int := s1'' Int.- s2'';
+      z' : Int := if (z Int.> 706) (z Int.- 32362) z;
+      z'' :
+        Int :=
+          if (z' Int.< 1) (z' Int.+ 32362) (Int.mod z (ofNat k1));
+    in toNat z'', stdGen (toNat s1'') (toNat s2'') (toNat s3'');
 
-stdSplit : StdGen -> StdGen × StdGen;
-stdSplit g@(stdGen s1 s2 s3) :=
-  let
-    newS1 : Nat := if (s1 == k1) 1 (s1 + 1);
-    newS2 : Nat := if (s2 == 1) k2 (sub s2 1);
-    newS3 : Nat := if (s3 == k3) 1 (s3 + 1);
-    newG : StdGen := snd (stdNext g);
-    leftG :
-      StdGen := stdGen newS1 (stdGenS2 newG) (stdGenS3 newG);
-    rightG : StdGen := stdGen (stdGenS1 newG) newS2 newS3;
-  in leftG, rightG;
+stdSplit : StdGen -> StdGen × StdGen
+  | g@(stdGen s1 s2 s3) :=
+    let
+      newS1 : Nat := if (s1 == k1) 1 (s1 + 1);
+      newS2 : Nat := if (s2 == 1) k2 (sub s2 1);
+      newS3 : Nat := if (s3 == k3) 1 (s3 + 1);
+      newG : StdGen := snd (stdNext g);
+      leftG :
+        StdGen := stdGen newS1 (stdGenS2 newG) (stdGenS3 newG);
+      rightG : StdGen := stdGen (stdGenS1 newG) newS2 newS3;
+    in leftG, rightG;
 
-randNatAux :
-  StdGen
+randNatAux
+  : StdGen
     -> Nat
     -> Nat
     -> Nat
     -> Nat × StdGen
-    -> Nat × StdGen;
-randNatAux g genLo genMag :=
-  let
-    terminating
-    go : Nat -> Nat × StdGen -> Nat × StdGen;
-    go zero p@(v, g) := p;
-    go r'@(suc _) (v, g) :=
-      let
-        n : Nat × StdGen := stdNext g;
-        v' : Nat := v * genMag + sub (fst n) genLo;
-      in go (div r' (sub genMag 1)) (v', snd n);
-  in go;
+    -> Nat × StdGen
+  | g genLo genMag :=
+    let
+      terminating
+      go : Nat -> Nat × StdGen -> Nat × StdGen;
+      go zero p@(v, g) := p;
+      go r'@(suc _) (v, g) :=
+        let
+          n : Nat × StdGen := stdNext g;
+          v' : Nat := v * genMag + sub (fst n) genLo;
+        in go (div r' (sub genMag 1)) (v', snd n);
+    in go;
 
-randNat : StdGen -> Nat -> Nat -> Nat × StdGen;
-randNat g lo hi :=
-  let
-    genLo : Nat := fst stdRange;
-    genHi : Nat := snd stdRange;
-    genMag : Nat := sub genHi genLo + 1;
-    q : Nat := 1000;
-    k : Nat := sub hi lo + 1;
-    tgtMag : Nat := k * q;
-    x : Nat × StdGen := randNatAux g genLo genMag tgtMag (0, g);
-    v : Nat := fst x;
-    g' : StdGen := snd x;
-    v' : Nat := lo + mod v k;
-  in v', g';
+randNat : StdGen -> Nat -> Nat -> Nat × StdGen
+  | g lo hi :=
+    let
+      genLo : Nat := fst stdRange;
+      genHi : Nat := snd stdRange;
+      genMag : Nat := sub genHi genLo + 1;
+      q : Nat := 1000;
+      k : Nat := sub hi lo + 1;
+      tgtMag : Nat := k * q;
+      x : Nat × StdGen := randNatAux g genLo genMag tgtMag (0, g);
+      v : Nat := fst x;
+      g' : StdGen := snd x;
+      v' : Nat := lo + mod v k;
+    in v', g';
 
-randBool : StdGen -> Bool × StdGen;
-randBool g :=
-  let
-    x : Nat × StdGen := randNat g 0 1;
-    b : Bool := fst x == 1;
-  in b, snd x;
+randBool : StdGen -> Bool × StdGen
+  | g :=
+    let
+      x : Nat × StdGen := randNat g 0 1;
+      b : Bool := fst x == 1;
+    in b, snd x;
 
-run : Nat -> StdGen -> IO;
-run zero _ := printString "";
-run (suc n) g :=
-  let
-    next : Nat × StdGen := randNat g 0 100;
-    b : Nat := fst next;
-    g' : StdGen := snd next;
-  in printNatLn b >> run n g';
+run : Nat -> StdGen -> IO
+  | zero _ := printString ""
+  | (suc n) g :=
+    let
+      next : Nat × StdGen := randNat g 0 100;
+      b : Nat := fst next;
+      g' : StdGen := snd next;
+    in printNatLn b >> run n g';
 
-main : IO;
-main :=
+main : IO :=
   let
     go : String -> IO;
     go s :=

--- a/Data/Random.juvix
+++ b/Data/Random.juvix
@@ -10,8 +10,7 @@ import Stdlib.Data.Int as Int open using {Int};
 
 import Stdlib.Data.Int.Ord as Int;
 
-type StdGen :=
-  | stdGen : Nat -> Nat -> Nat -> StdGen;
+type StdGen := stdGen : Nat -> Nat -> Nat -> StdGen;
 
 stdGenS1 : StdGen -> Nat
   | (stdGen s1 _ _) := s1;

--- a/Data/Random.juvix
+++ b/Data/Random.juvix
@@ -47,24 +47,21 @@ stdNext : StdGen -> Nat × StdGen
       s2 : Int := ofNat s2Nat;
       s3 : Int := ofNat s3Nat;
       k : Int := Int.div s1 206;
-      s1' :
-        Int := 157 Int.* (s1 Int.- k Int.* 206) Int.- k Int.* 21;
+      s1' : Int :=
+        157 Int.* (s1 Int.- k Int.* 206) Int.- k Int.* 21;
       s1'' : Int := if (s1' Int.< 0) (s1' Int.+ 32363) s1';
       k' : Int := Int.div s2 217;
-      s2' :
-        Int :=
-          146 Int.* (s2 Int.- k' Int.* 217) Int.- k' Int.* 45;
+      s2' : Int :=
+        146 Int.* (s2 Int.- k' Int.* 217) Int.- k' Int.* 45;
       s2'' : Int := if (s2' Int.< 0) (s2' Int.+ 31727) s2';
       k'' : Int := Int.div s3 222;
-      s3' :
-        Int :=
-          142 Int.* (s3 Int.- k' Int.* 222) Int.- k' Int.* 133;
+      s3' : Int :=
+        142 Int.* (s3 Int.- k' Int.* 222) Int.- k' Int.* 133;
       s3'' : Int := if (s2' Int.< 0) (s2' Int.+ 31657) s3';
       z : Int := s1'' Int.- s2'';
       z' : Int := if (z Int.> 706) (z Int.- 32362) z;
-      z'' :
-        Int :=
-          if (z' Int.< 1) (z' Int.+ 32362) (Int.mod z (ofNat k1));
+      z'' : Int :=
+        if (z' Int.< 1) (z' Int.+ 32362) (Int.mod z (ofNat k1));
     in toNat z'', stdGen (toNat s1'') (toNat s2'') (toNat s3'');
 
 stdSplit : StdGen -> StdGen × StdGen
@@ -74,8 +71,8 @@ stdSplit : StdGen -> StdGen × StdGen
       newS2 : Nat := if (s2 == 1) k2 (sub s2 1);
       newS3 : Nat := if (s3 == k3) 1 (s3 + 1);
       newG : StdGen := snd (stdNext g);
-      leftG :
-        StdGen := stdGen newS1 (stdGenS2 newG) (stdGenS3 newG);
+      leftG : StdGen :=
+        stdGen newS1 (stdGenS2 newG) (stdGenS3 newG);
       rightG : StdGen := stdGen (stdGenS1 newG) newS2 newS3;
     in leftG, rightG;
 
@@ -89,13 +86,13 @@ randNatAux
   | g genLo genMag :=
     let
       terminating
-      go : Nat -> Nat × StdGen -> Nat × StdGen;
-      go zero p@(v, g) := p;
-      go r'@(suc _) (v, g) :=
-        let
-          n : Nat × StdGen := stdNext g;
-          v' : Nat := v * genMag + sub (fst n) genLo;
-        in go (div r' (sub genMag 1)) (v', snd n);
+      go : Nat -> Nat × StdGen -> Nat × StdGen
+        | zero p@(v, g) := p
+        | r'@(suc _) (v, g) :=
+          let
+            n : Nat × StdGen := stdNext g;
+            v' : Nat := v * genMag + sub (fst n) genLo;
+          in go (div r' (sub genMag 1)) (v', snd n);
     in go;
 
 randNat : StdGen -> Nat -> Nat -> Nat × StdGen
@@ -131,10 +128,10 @@ run : Nat -> StdGen -> IO
 
 main : IO :=
   let
-    go : String -> IO;
-    go s :=
-      let
-        seed : Nat := stringToNat s;
-        initG : StdGen := mkStdGen seed;
-      in run 100 initG;
+    go : String -> IO
+      | s :=
+        let
+          seed : Nat := stringToNat s;
+          initG : StdGen := mkStdGen seed;
+        in run 100 initG;
   in readLn go;

--- a/Data/String.juvix
+++ b/Data/String.juvix
@@ -4,9 +4,8 @@ import Stdlib.Prelude open;
 
 import Data.Monoid as Monoid;
 
-intercalate : String → List String → String;
-intercalate sep xs :=
-  Monoid.mconcat Monoid.string (intersperse sep xs);
+intercalate : String → List String → String
+  | sep xs :=
+    Monoid.mconcat Monoid.string (intersperse sep xs);
 
-lines : List String -> String;
-lines := intercalate "\n";
+lines : List String -> String := intercalate "\n";

--- a/Example.juvix
+++ b/Example.juvix
@@ -26,8 +26,8 @@ prop-tailLengthOneLess : List Int -> Bool
 
 prop-splitAtRecombine : Nat -> List Int -> Bool
   | n xs :=
-    case splitAt n xs
-      | lhs, rhs := eqListInt xs (lhs ++ rhs);
+    case splitAt n xs of {lhs, rhs :=
+      eqListInt xs (lhs ++ rhs)};
 
 prop-mergeSumLengths : List Int -> List Int -> Bool
   | xs ys :=
@@ -36,11 +36,10 @@ prop-mergeSumLengths : List Int -> List Int -> Bool
 
 prop-partition : List Int -> (Int -> Bool) -> Bool
   | xs p :=
-    case partition p xs
-      | lhs, rhs :=
-        all p lhs
-          && not (any p rhs)
-          && eqListInt (sortInt xs) (sortInt (lhs ++ rhs));
+    case partition p xs of {lhs, rhs :=
+      all p lhs
+        && not (any p rhs)
+        && eqListInt (sortInt xs) (sortInt (lhs ++ rhs))};
 
 prop-distributive : Int -> Int -> (Int -> Int) -> Bool
   | a b f := f (a + b) == f a + f b;
@@ -56,49 +55,49 @@ prop-gcd-bad : Int -> Int -> Bool
 
 gcdNoCoprimeTest : QC.Test :=
   QC.mkTest
-    QC.testableBinaryInt
+    {{QC.testableFunction2}}
     "no integers are coprime"
     prop-gcd-bad;
 
 partitionTest : QC.Test :=
   QC.mkTest
-    QC.testableListIntHofIntBool
+    {{QC.testableHof1}}
     "partition: recombination of the output equals the input"
     prop-partition;
 
 testDistributive : QC.Test :=
   QC.mkTest
-    QC.testableIntIntHofIntInt
+    {{QC.testableHof2}}
     "all functions are distributive over +"
     prop-distributive;
 
 reverseLengthTest : QC.Test :=
   QC.mkTest
-    QC.testableListInt
+    {{QC.testableFunction}}
     "reverse preserves length"
     prop-reverseDoesNotChangeLength;
 
 reverseReverseIdTest : QC.Test :=
   QC.mkTest
-    QC.testableListInt
+    {{QC.testableFunction}}
     "reverse of reverse is identity"
     prop-reverseReverseIsIdentity;
 
 splitAtRecombineTest : QC.Test :=
   QC.mkTest
-    QC.testableNatListInt
+    {{QC.testableFunction2}}
     "splitAt: recombination of the output is equal to the input list"
     prop-splitAtRecombine;
 
 mergeSumLengthsTest : QC.Test :=
   QC.mkTest
-    QC.testableListIntListInt
+    {{QC.testableFunction2}}
     "merge: sum of the lengths of input lists is equal to the length of output list"
     prop-mergeSumLengths;
 
 tailLengthOneLessTest : QC.Test :=
   QC.mkTest
-    QC.testableListInt
+    {{QC.testableFunction}}
     "tail: length of output is one less than input unless empty"
     prop-tailLengthOneLess;
 
@@ -108,10 +107,4 @@ main : IO :=
       QC.runTestsIO
         100
         (stringToNat seed)
-        (partitionTest
-          :: reverseLengthTest
-          :: reverseReverseIdTest
-          :: splitAtRecombineTest
-          :: mergeSumLengthsTest
-          :: tailLengthOneLessTest
-          :: nil)};
+        [partitionTest; reverseLengthTest; reverseReverseIdTest; splitAtRecombineTest; mergeSumLengthsTest; tailLengthOneLessTest]};

--- a/Example.juvix
+++ b/Example.juvix
@@ -32,7 +32,7 @@ prop-splitAtRecombine : Nat -> List Int -> Bool
 prop-mergeSumLengths : List Int -> List Int -> Bool
   | xs ys :=
     length xs Nat.+ length ys
-      Nat.== length (merge IntTraits.Ord xs ys);
+      Nat.== length (merge ordIntI xs ys);
 
 prop-partition : List Int -> (Int -> Bool) -> Bool
   | xs p :=

--- a/Example.juvix
+++ b/Example.juvix
@@ -13,107 +13,96 @@ import Data.Int open;
 
 import Test.QuickCheckTest as QC;
 
-prop-reverseDoesNotChangeLength : List Int -> Bool;
-prop-reverseDoesNotChangeLength xs :=
-  length (reverse xs) Nat.== length xs;
+prop-reverseDoesNotChangeLength : List Int -> Bool
+  | xs := length (reverse xs) Nat.== length xs;
 
-prop-reverseReverseIsIdentity : List Int -> Bool;
-prop-reverseReverseIsIdentity xs :=
-  eqListInt xs (reverse (reverse xs));
+prop-reverseReverseIsIdentity : List Int -> Bool
+  | xs := eqListInt xs (reverse (reverse xs));
 
-prop-tailLengthOneLess : List Int -> Bool;
-prop-tailLengthOneLess xs :=
-  null xs
-    || ofNat (length (tail xs)) == intSubNat (length xs) 1;
+prop-tailLengthOneLess : List Int -> Bool
+  | xs :=
+    null xs
+      || ofNat (length (tail xs)) == intSubNat (length xs) 1;
 
-prop-splitAtRecombine : Nat -> List Int -> Bool;
-prop-splitAtRecombine n xs :=
-  case splitAt n xs
-    | lhs, rhs := eqListInt xs (lhs ++ rhs);
+prop-splitAtRecombine : Nat -> List Int -> Bool
+  | n xs :=
+    case splitAt n xs
+      | lhs, rhs := eqListInt xs (lhs ++ rhs);
 
-prop-mergeSumLengths : List Int -> List Int -> Bool;
-prop-mergeSumLengths xs ys :=
-  length xs Nat.+ length ys
-    Nat.== length (merge IntTraits.Ord xs ys);
+prop-mergeSumLengths : List Int -> List Int -> Bool
+  | xs ys :=
+    length xs Nat.+ length ys
+      Nat.== length (merge IntTraits.Ord xs ys);
 
-prop-partition : List Int -> (Int -> Bool) -> Bool;
-prop-partition xs p :=
-  case partition p xs
-    | lhs, rhs :=
-      all p lhs
-        && not (any p rhs)
-        && eqListInt (sortInt xs) (sortInt (lhs ++ rhs));
+prop-partition : List Int -> (Int -> Bool) -> Bool
+  | xs p :=
+    case partition p xs
+      | lhs, rhs :=
+        all p lhs
+          && not (any p rhs)
+          && eqListInt (sortInt xs) (sortInt (lhs ++ rhs));
 
-prop-distributive : Int -> Int -> (Int -> Int) -> Bool;
-prop-distributive a b f := f (a + b) == f a + f b;
+prop-distributive : Int -> Int -> (Int -> Int) -> Bool
+  | a b f := f (a + b) == f a + f b;
 
-prop-add-sub : Int -> Int -> Bool;
-prop-add-sub a b := a == a + b - b;
+prop-add-sub : Int -> Int -> Bool
+  | a b := a == a + b - b;
 
-prop-add-sub-bad : Int -> Int -> Bool;
-prop-add-sub-bad a b := a == 2;
+prop-add-sub-bad : Int -> Int -> Bool
+  | a b := a == 2;
 
-prop-gcd-bad : Int -> Int -> Bool;
-prop-gcd-bad a b := gcd a b > 1;
+prop-gcd-bad : Int -> Int -> Bool
+  | a b := gcd a b > 1;
 
-gcdNoCoprimeTest : QC.Test;
-gcdNoCoprimeTest :=
+gcdNoCoprimeTest : QC.Test :=
   QC.mkTest
     QC.testableBinaryInt
     "no integers are coprime"
     prop-gcd-bad;
 
-partitionTest : QC.Test;
-partitionTest :=
+partitionTest : QC.Test :=
   QC.mkTest
     QC.testableListIntHofIntBool
     "partition: recombination of the output equals the input"
     prop-partition;
 
-testDistributive : QC.Test;
-testDistributive :=
+testDistributive : QC.Test :=
   QC.mkTest
     QC.testableIntIntHofIntInt
     "all functions are distributive over +"
     prop-distributive;
 
-reverseLengthTest : QC.Test;
-reverseLengthTest :=
+reverseLengthTest : QC.Test :=
   QC.mkTest
     QC.testableListInt
     "reverse preserves length"
     prop-reverseDoesNotChangeLength;
 
-reverseReverseIdTest : QC.Test;
-reverseReverseIdTest :=
+reverseReverseIdTest : QC.Test :=
   QC.mkTest
     QC.testableListInt
     "reverse of reverse is identity"
     prop-reverseReverseIsIdentity;
 
-splitAtRecombineTest : QC.Test;
-splitAtRecombineTest :=
+splitAtRecombineTest : QC.Test :=
   QC.mkTest
     QC.testableNatListInt
     "splitAt: recombination of the output is equal to the input list"
     prop-splitAtRecombine;
 
-mergeSumLengthsTest : QC.Test;
-mergeSumLengthsTest :=
+mergeSumLengthsTest : QC.Test :=
   QC.mkTest
     QC.testableListIntListInt
     "merge: sum of the lengths of input lists is equal to the length of output list"
     prop-mergeSumLengths;
 
-tailLengthOneLessTest : QC.Test;
-tailLengthOneLessTest :=
+tailLengthOneLessTest : QC.Test :=
   QC.mkTest
     QC.testableListInt
     "tail: length of output is one less than input unless empty"
     prop-tailLengthOneLess;
 
-main : IO;
-main :=
+main : IO :=
   readLn
     \ {seed :=
       QC.runTestsIO

--- a/Example.juvix
+++ b/Example.juvix
@@ -11,93 +11,105 @@ import Data.List open;
 import Data.String open;
 import Data.Int open;
 
-import Test.QuickCheckTest as QC;
+import Test.QuickCheckTest as QC open using {Fun; mkFun; module Fun};
 
-prop-reverseDoesNotChangeLength : List Int -> Bool
-  | xs := length (reverse xs) Nat.== length xs;
+prop-reverseDoesNotChangeLength : Fun (List Int) Bool :=
+  mkFun \ {xs := length (reverse xs) Nat.== length xs};
 
-prop-reverseReverseIsIdentity : List Int -> Bool
-  | xs := eqListInt xs (reverse (reverse xs));
+prop-reverseReverseIsIdentity : Fun (List Int) Bool :=
+  mkFun \ {xs := eqListInt xs (reverse (reverse xs))};
 
-prop-tailLengthOneLess : List Int -> Bool
-  | xs :=
-    null xs
-      || ofNat (length (tail xs)) == intSubNat (length xs) 1;
+prop-tailLengthOneLess : Fun (List Int) Bool :=
+  mkFun
+    \ {xs :=
+      null xs
+        || ofNat (length (tail xs)) == intSubNat (length xs) 1};
 
-prop-splitAtRecombine : Nat -> List Int -> Bool
-  | n xs :=
-    case splitAt n xs of {lhs, rhs :=
-      eqListInt xs (lhs ++ rhs)};
+prop-splitAtRecombine : Fun Nat (Fun (List Int) Bool) :=
+  mkFun
+    \ {n :=
+      mkFun
+        \ {xs :=
+          case splitAt n xs of {lhs, rhs :=
+            eqListInt xs (lhs ++ rhs)}}};
 
-prop-mergeSumLengths : List Int -> List Int -> Bool
-  | xs ys :=
-    length xs Nat.+ length ys
-      Nat.== length (merge ordIntI xs ys);
+prop-mergeSumLengths
+  : Fun (List Int) (Fun (List Int) Bool) :=
+  mkFun
+    \ {xs :=
+      mkFun
+        \ {ys :=
+          length xs Nat.+ length ys
+            Nat.== length (merge ordIntI xs ys)}};
 
-prop-partition : List Int -> (Int -> Bool) -> Bool
-  | xs p :=
-    case partition p xs of {lhs, rhs :=
-      all p lhs
-        && not (any p rhs)
-        && eqListInt (sortInt xs) (sortInt (lhs ++ rhs))};
+prop-partition : Fun (List Int) (Fun (Fun Int Bool) Bool) :=
+  mkFun
+    \ {xs :=
+      mkFun
+        \ {pFun :=
+          let
+            p : Int -> Bool := Fun.fun pFun;
+          in case partition p xs of {lhs, rhs :=
+            all p lhs
+              && not (any p rhs)
+              && eqListInt (sortInt xs) (sortInt (lhs ++ rhs))}}};
 
-prop-distributive : Int -> Int -> (Int -> Int) -> Bool
-  | a b f := f (a + b) == f a + f b;
+prop-distributive
+  : Fun Int (Fun Int (Fun (Fun Int Int) Bool)) :=
+  mkFun
+    \ {a :=
+      mkFun
+        \ {b :=
+          mkFun
+            \ {fFun :=
+              let
+                f : Int -> Int := Fun.fun fFun;
+              in f (a + b) == f a + f b}}};
 
-prop-add-sub : Int -> Int -> Bool
-  | a b := a == a + b - b;
+prop-add-sub : Fun Int (Fun Int Bool) :=
+  mkFun \ {a := mkFun \ {b := a == a + b - b}};
 
-prop-add-sub-bad : Int -> Int -> Bool
-  | a b := a == 2;
+prop-add-sub-bad : Fun Int (Fun Int Bool) :=
+  mkFun \ {a := mkFun \ {b := a == 2}};
 
-prop-gcd-bad : Int -> Int -> Bool
-  | a b := gcd a b > 1;
+prop-gcd-bad : Fun Int (Fun Int Bool) :=
+  mkFun \ {a := mkFun \ {b := gcd a b > 1}};
 
 gcdNoCoprimeTest : QC.Test :=
-  QC.mkTest
-    {{QC.testableFunction2}}
-    "no integers are coprime"
-    prop-gcd-bad;
+  QC.mkTest "no integers are coprime" prop-gcd-bad;
 
 partitionTest : QC.Test :=
   QC.mkTest
-    {{QC.testableHof1}}
     "partition: recombination of the output equals the input"
     prop-partition;
 
 testDistributive : QC.Test :=
   QC.mkTest
-    {{QC.testableHof2}}
     "all functions are distributive over +"
     prop-distributive;
 
 reverseLengthTest : QC.Test :=
   QC.mkTest
-    {{QC.testableFunction}}
     "reverse preserves length"
     prop-reverseDoesNotChangeLength;
 
 reverseReverseIdTest : QC.Test :=
   QC.mkTest
-    {{QC.testableFunction}}
     "reverse of reverse is identity"
     prop-reverseReverseIsIdentity;
 
 splitAtRecombineTest : QC.Test :=
   QC.mkTest
-    {{QC.testableFunction2}}
     "splitAt: recombination of the output is equal to the input list"
     prop-splitAtRecombine;
 
 mergeSumLengthsTest : QC.Test :=
   QC.mkTest
-    {{QC.testableFunction2}}
     "merge: sum of the lengths of input lists is equal to the length of output list"
     prop-mergeSumLengths;
 
 tailLengthOneLessTest : QC.Test :=
   QC.mkTest
-    {{QC.testableFunction}}
     "tail: length of output is one less than input unless empty"
     prop-tailLengthOneLess;
 

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ all: run-quickcheck
 deps/stdlib:
 	@mkdir -p deps/
 	@git clone https://github.com/anoma/juvix-stdlib.git deps/stdlib
-	@git -C deps/stdlib checkout d79ba94cc31319d06b76e159e6e5e1c6de95c368
+	@git -C deps/stdlib checkout b7edcc335feee4e3db87b5aca46381e2d9644ab0
 
 .PHONY: deps
 deps: deps/stdlib

--- a/Makefile
+++ b/Makefile
@@ -1,18 +1,10 @@
 
 all: run-quickcheck
 
-deps/stdlib:
-	@mkdir -p deps/
-	@git clone https://github.com/anoma/juvix-stdlib.git deps/stdlib
-	@git -C deps/stdlib checkout b7edcc335feee4e3db87b5aca46381e2d9644ab0
-
-.PHONY: deps
-deps: deps/stdlib
-
-build/Random: Data/Random.juvix deps
+build/Random: Data/Random.juvix
 	juvix compile Data/Random.juvix -o build/Random
 
-build/Example: $(wildcard ./**/*.juvix) Example.juvix deps
+build/Example: $(wildcard ./**/*.juvix) Example.juvix
 	@mkdir -p build
 	juvix compile Example.juvix -o build/Example
 
@@ -30,7 +22,7 @@ clean-build:
 
 .PHONY: clean-deps
 clean-deps:
-	@rm -rf deps/
+	juvix clean
 
 .PHONY: clean
 clean: clean-deps clean-build

--- a/README.md
+++ b/README.md
@@ -12,24 +12,20 @@ module Example;
 import Stdlib.Prelude open;
 import Stdlib.Data.Nat.Ord open;
 
-import Test.QuickCheckTest as QC;
+import Test.QuickCheckTest as QC open using {Fun; mkFun};
 
-prop-partition (xs : List Int) (p : Int -> Bool) : Bool :=
-  case partition p xs of {lhs, rhs :=
-    all p lhs
-      && not (any p rhs)
-      && length xs == length (lhs ++ rhs)};
+prop-reverseReverseIsIdentity : Fun (List Int) Bool :=
+  mkFun \ {xs := Eq.eq xs (reverse (reverse xs))};
 
-partitionTest : QC.Test :=
+reverseTest : QC.Test :=
   QC.mkTest
-    {{QC.testableHof1}}
-    "partition: test predicate on result"
-    prop-partition;
+    "reverse of reverse is identity"
+    prop-reverseReverseIsIdentity;
 
 main : IO :=
   readLn
-    \ {| seed :=
-      QC.runTestsIO 100 (stringToNat seed) [partitionTest]};
+    \ {seed :=
+      QC.runTestsIO 100 (stringToNat seed) [reverseTest]};
 ```
 
 To run this you need to pass a random seed to the runner:

--- a/README.md
+++ b/README.md
@@ -9,35 +9,27 @@ Here's an example module that defines and tests a property.
 ```
 module Example;
 
-open import Stdlib.Prelude;
-open import Stdlib.Data.Nat.Ord;
+import Stdlib.Prelude open;
+import Stdlib.Data.Nat.Ord open;
 
 import Test.QuickCheckTest as QC;
 
-prop-partition : List Int -> (Int -> Bool) -> Bool;
-prop-partition xs p :=
-  case partition p xs
-    | lhs, rhs :=
-      all p lhs
-        && not (any p rhs)
-        && length xs == length (lhs ++ rhs);
+prop-partition (xs : List Int) (p : Int -> Bool) : Bool :=
+  case partition p xs of {lhs, rhs :=
+    all p lhs
+      && not (any p rhs)
+      && length xs == length (lhs ++ rhs)};
 
-partitionTest : QC.Test;
-partitionTest :=
+partitionTest : QC.Test :=
   QC.mkTest
-    QC.testableListIntHofIntBool
+    {{QC.testableHof1}}
     "partition: test predicate on result"
     prop-partition;
 
-main : IO;
-main :=
+main : IO :=
   readLn
-    \ {
-      | seed := QC.runTestsIO
-        100
-        (stringToNat seed)
-        (partitionTest :: nil)
-    };
+    \ {| seed :=
+      QC.runTestsIO 100 (stringToNat seed) [partitionTest]};
 ```
 
 To run this you need to pass a random seed to the runner:

--- a/Test/QuickCheck.juvix
+++ b/Test/QuickCheck.juvix
@@ -8,22 +8,22 @@ import Test.QuickCheck.Property open public;
 import Test.QuickCheck.Result open public;
 import Test.QuickCheck.Testable open public;
 
-quickcheck :
-  {Predicate : Type}
+quickcheck
+  : {Predicate : Type}
     -> Nat
     -> Nat
     -> Testable Predicate
     -> Predicate
-    -> Result;
-quickcheck attemptNum startSeed t predicate :=
-  let
-    seeds : List Nat;
-    seeds := map (n in range attemptNum) startSeed + n;
-    runOne : Property -> Nat -> Result;
-    runOne prop seed :=
-      let
-        result : Result := runProp prop (mkStdGen seed);
-      in overFailure result \ {(failure _ cs) := failure seed cs};
-    runAll : Property -> Result;
-    runAll prop := foldMap monoidResult (runOne prop) seeds;
-  in runAll (toProp t predicate);
+    -> Result
+  | attemptNum startSeed t predicate :=
+    let
+      seeds : List Nat;
+      seeds := map (n in range attemptNum) startSeed + n;
+      runOne : Property -> Nat -> Result;
+      runOne prop seed :=
+        let
+          result : Result := runProp prop (mkStdGen seed);
+        in overFailure result \ {(failure _ cs) := failure seed cs};
+      runAll : Property -> Result;
+      runAll prop := foldMap monoidResult (runOne prop) seeds;
+    in runAll (toProp t predicate);

--- a/Test/QuickCheck.juvix
+++ b/Test/QuickCheck.juvix
@@ -7,6 +7,7 @@ import Data.Random open;
 import Test.QuickCheck.Property open public;
 import Test.QuickCheck.Result open public;
 import Test.QuickCheck.Testable open public;
+import Test.QuickCheck.Fun open public;
 
 quickcheck {Predicate : Type} {{Testable Predicate}}
   : Nat -> Nat -> Predicate -> Result

--- a/Test/QuickCheck.juvix
+++ b/Test/QuickCheck.juvix
@@ -8,23 +8,17 @@ import Test.QuickCheck.Property open public;
 import Test.QuickCheck.Result open public;
 import Test.QuickCheck.Testable open public;
 
-quickcheck
-  : {Predicate : Type}
-    -> Nat
-    -> Nat
-    -> Testable Predicate
-    -> Predicate
-    -> Result
-  | attemptNum startSeed t predicate :=
+quickcheck {Predicate : Type} {{Testable Predicate}}
+  : Nat -> Nat -> Predicate -> Result
+  | attemptNum startSeed predicate :=
     let
       seeds : List Nat :=
         map (n in range attemptNum)
           startSeed + n;
-      runOne : Property -> Nat -> Result
-        | prop seed :=
-          let
-            result : Result := runProp prop (mkStdGen seed);
-          in overFailure result \ {(failure _ cs) := failure seed cs};
-      runAll : Property -> Result
-        | prop := foldMap monoidResult (runOne prop) seeds;
-    in runAll (toProp t predicate);
+      runOne (prop : Property) (seed : Nat) : Result :=
+        let
+          result : Result := runProp prop (mkStdGen seed);
+        in overFailure result \ {(failure _ cs) := failure seed cs};
+      runAll (prop : Property) : Result :=
+        foldMap monoidResult (runOne prop) seeds;
+    in runAll (Testable.toProp predicate);

--- a/Test/QuickCheck.juvix
+++ b/Test/QuickCheck.juvix
@@ -17,13 +17,14 @@ quickcheck
     -> Result
   | attemptNum startSeed t predicate :=
     let
-      seeds : List Nat;
-      seeds := map (n in range attemptNum) startSeed + n;
-      runOne : Property -> Nat -> Result;
-      runOne prop seed :=
-        let
-          result : Result := runProp prop (mkStdGen seed);
-        in overFailure result \ {(failure _ cs) := failure seed cs};
-      runAll : Property -> Result;
-      runAll prop := foldMap monoidResult (runOne prop) seeds;
+      seeds : List Nat :=
+        map (n in range attemptNum)
+          startSeed + n;
+      runOne : Property -> Nat -> Result
+        | prop seed :=
+          let
+            result : Result := runProp prop (mkStdGen seed);
+          in overFailure result \ {(failure _ cs) := failure seed cs};
+      runAll : Property -> Result
+        | prop := foldMap monoidResult (runOne prop) seeds;
     in runAll (toProp t predicate);

--- a/Test/QuickCheck/Arbitrary.juvix
+++ b/Test/QuickCheck/Arbitrary.juvix
@@ -3,6 +3,7 @@ module Test.QuickCheck.Arbitrary;
 import Stdlib.Prelude open;
 import Data.Random open;
 import Test.QuickCheck.Gen open;
+import Test.QuickCheck.Fun open;
 import Test.QuickCheck.CoArbitrary open;
 
 -- | A generator associated with a type A
@@ -31,11 +32,6 @@ instance
 arbitraryBool : Arbitrary Bool :=
   mkArbitrary (mkGen \ {rand := fst (randBool rand)});
 
-arbitraryFunction {A B} {{CoArbitrary A B}} {{Arbitrary B}}
-  : Arbitrary (A -> B) :=
-  mkArbitrary
-    (promote (CoArbitrary.coarbitrary Arbitrary.gen));
-
 instance
 arbitraryList {A} {{Arbitrary A}} : Arbitrary (List A) :=
   mkArbitrary
@@ -55,3 +51,9 @@ arbitraryList {A} {{Arbitrary A}} : Arbitrary (List A) :=
                 r2 : StdGen := snd rSplit;
               in Gen.run Arbitrary.gen r1 :: randList r2 n;
         in randList rand2 len});
+
+instance
+arbitraryFunction {A B} {{CoArbitrary A B}} {{Arbitrary B}}
+  : Arbitrary (Fun A B) :=
+  mkArbitrary
+    (promoteFun (CoArbitrary.coarbitrary Arbitrary.gen));

--- a/Test/QuickCheck/Arbitrary.juvix
+++ b/Test/QuickCheck/Arbitrary.juvix
@@ -6,18 +6,20 @@ import Test.QuickCheck.Gen open;
 import Test.QuickCheck.CoArbitrary open;
 
 -- | A generator associated with a type A
-type Arbitrary (A : Type) :=
-  | arbitrary : Gen A -> Arbitrary A;
+trait
+type Arbitrary (A : Type) := mkArbitrary {gen : Gen A};
 
-runArb : {A : Type} -> Arbitrary A -> StdGen -> A
-  | (arbitrary g) rand := runGen g rand;
+runArb {A} {{Arbitrary A}} (rand : StdGen) : A :=
+  Gen.run Arbitrary.gen rand;
 
+instance
 arbitraryNat : Arbitrary Nat :=
-  arbitrary (gen \ {rand := fst (stdNext rand)});
+  mkArbitrary (mkGen \ {rand := fst (stdNext rand)});
 
+instance
 arbitraryInt : Arbitrary Int :=
-  arbitrary
-    (gen
+  mkArbitrary
+    (mkGen
       \ {rand :=
         let
           runRand : Nat × StdGen := stdNext rand;
@@ -25,35 +27,31 @@ arbitraryInt : Arbitrary Int :=
           isPos : Bool := fst (randBool (snd runRand));
         in if isPos (ofNat n) (negSuc n)});
 
+instance
 arbitraryBool : Arbitrary Bool :=
-  arbitrary (gen \ {rand := fst (randBool rand)});
+  mkArbitrary (mkGen \ {rand := fst (randBool rand)});
 
-arbitraryFunction
-  : {A : Type}
-    -> {B : Type}
-    -> CoArbitrary A B
-    -> Arbitrary B
-    -> Arbitrary (A -> B)
-  | (coarbitrary f) (arbitrary g) :=
-    arbitrary (promote (f g));
+arbitraryFunction {A B} {{CoArbitrary A B}} {{Arbitrary B}}
+  : Arbitrary (A -> B) :=
+  mkArbitrary
+    (promote (CoArbitrary.coarbitrary Arbitrary.gen));
 
-arbitraryList
-  : {A : Type} -> Arbitrary A -> Arbitrary (List A)
-  | {A} (arbitrary g) :=
-    arbitrary
-      (gen
-        \ {rand :=
-          let
-            randSplit : StdGen × StdGen := stdSplit rand;
-            rand1 : StdGen := fst randSplit;
-            rand2 : StdGen := snd randSplit;
-            len : Nat := fst (randNat rand1 0 10);
-            randList : StdGen -> Nat -> List A
-              | _ zero := nil
-              | r (suc n) :=
-                let
-                  rSplit : StdGen × StdGen := stdSplit r;
-                  r1 : StdGen := fst rSplit;
-                  r2 : StdGen := snd rSplit;
-                in runGen g r1 :: randList r2 n;
-          in randList rand2 len});
+instance
+arbitraryList {A} {{Arbitrary A}} : Arbitrary (List A) :=
+  mkArbitrary
+    (mkGen
+      \ {rand :=
+        let
+          randSplit : StdGen × StdGen := stdSplit rand;
+          rand1 : StdGen := fst randSplit;
+          rand2 : StdGen := snd randSplit;
+          len : Nat := fst (randNat rand1 0 10);
+          randList : StdGen -> Nat -> List A
+            | _ zero := nil
+            | r (suc n) :=
+              let
+                rSplit : StdGen × StdGen := stdSplit r;
+                r1 : StdGen := fst rSplit;
+                r2 : StdGen := snd rSplit;
+              in Gen.run Arbitrary.gen r1 :: randList r2 n;
+        in randList rand2 len});

--- a/Test/QuickCheck/Arbitrary.juvix
+++ b/Test/QuickCheck/Arbitrary.juvix
@@ -9,15 +9,13 @@ import Test.QuickCheck.CoArbitrary open;
 type Arbitrary (A : Type) :=
   | arbitrary : Gen A -> Arbitrary A;
 
-runArb : {A : Type} -> Arbitrary A -> StdGen -> A;
-runArb (arbitrary g) rand := runGen g rand;
+runArb : {A : Type} -> Arbitrary A -> StdGen -> A
+  | (arbitrary g) rand := runGen g rand;
 
-arbitraryNat : Arbitrary Nat;
-arbitraryNat :=
+arbitraryNat : Arbitrary Nat :=
   arbitrary (gen \ {rand := fst (stdNext rand)});
 
-arbitraryInt : Arbitrary Int;
-arbitraryInt :=
+arbitraryInt : Arbitrary Int :=
   arbitrary
     (gen
       \ {rand :=
@@ -27,37 +25,36 @@ arbitraryInt :=
           isPos : Bool := fst (randBool (snd runRand));
         in if isPos (ofNat n) (negSuc n)});
 
-arbitraryBool : Arbitrary Bool;
-arbitraryBool :=
+arbitraryBool : Arbitrary Bool :=
   arbitrary (gen \ {rand := fst (randBool rand)});
 
-arbitraryFunction :
-  {A : Type}
+arbitraryFunction
+  : {A : Type}
     -> {B : Type}
     -> CoArbitrary A B
     -> Arbitrary B
-    -> Arbitrary (A -> B);
-arbitraryFunction (coarbitrary f) (arbitrary g) :=
-  arbitrary (promote (f g));
+    -> Arbitrary (A -> B)
+  | (coarbitrary f) (arbitrary g) :=
+    arbitrary (promote (f g));
 
-arbitraryList :
-  {A : Type} -> Arbitrary A -> Arbitrary (List A);
-arbitraryList {A} (arbitrary g) :=
-  arbitrary
-    (gen
-      \ {rand :=
-        let
-          randSplit : StdGen × StdGen := stdSplit rand;
-          rand1 : StdGen := fst randSplit;
-          rand2 : StdGen := snd randSplit;
-          len : Nat := fst (randNat rand1 0 10);
-          randList : StdGen -> Nat -> List A;
-          randList _ zero := nil;
-          randList r (suc n) :=
-            let
-              rSplit : StdGen × StdGen;
-              rSplit := stdSplit r;
-              r1 : StdGen := fst rSplit;
-              r2 : StdGen := snd rSplit;
-            in runGen g r1 :: randList r2 n;
-        in randList rand2 len});
+arbitraryList
+  : {A : Type} -> Arbitrary A -> Arbitrary (List A)
+  | {A} (arbitrary g) :=
+    arbitrary
+      (gen
+        \ {rand :=
+          let
+            randSplit : StdGen × StdGen := stdSplit rand;
+            rand1 : StdGen := fst randSplit;
+            rand2 : StdGen := snd randSplit;
+            len : Nat := fst (randNat rand1 0 10);
+            randList : StdGen -> Nat -> List A;
+            randList _ zero := nil;
+            randList r (suc n) :=
+              let
+                rSplit : StdGen × StdGen;
+                rSplit := stdSplit r;
+                r1 : StdGen := fst rSplit;
+                r2 : StdGen := snd rSplit;
+              in runGen g r1 :: randList r2 n;
+          in randList rand2 len});

--- a/Test/QuickCheck/Arbitrary.juvix
+++ b/Test/QuickCheck/Arbitrary.juvix
@@ -48,13 +48,12 @@ arbitraryList
             rand1 : StdGen := fst randSplit;
             rand2 : StdGen := snd randSplit;
             len : Nat := fst (randNat rand1 0 10);
-            randList : StdGen -> Nat -> List A;
-            randList _ zero := nil;
-            randList r (suc n) :=
-              let
-                rSplit : StdGen × StdGen;
-                rSplit := stdSplit r;
-                r1 : StdGen := fst rSplit;
-                r2 : StdGen := snd rSplit;
-              in runGen g r1 :: randList r2 n;
+            randList : StdGen -> Nat -> List A
+              | _ zero := nil
+              | r (suc n) :=
+                let
+                  rSplit : StdGen × StdGen := stdSplit r;
+                  r1 : StdGen := fst rSplit;
+                  r2 : StdGen := snd rSplit;
+                in runGen g r1 :: randList r2 n;
           in randList rand2 len});

--- a/Test/QuickCheck/CoArbitrary.juvix
+++ b/Test/QuickCheck/CoArbitrary.juvix
@@ -17,22 +17,23 @@ binaryDigits : Nat -> List Nat
   | n :=
     let
       terminating
-      go : Nat -> List Nat;
-      go n :=
-        if (n Nat.== 0) nil (Nat.mod n 2 :: go (Nat.div n 2));
+      go : Nat -> List Nat
+        | n :=
+          if (n Nat.== 0) nil (Nat.mod n 2 :: go (Nat.div n 2));
     in reverse (go n);
 
 perturb : Int -> StdGen -> StdGen
   | n rand0 :=
     let
-      vary : Bool -> StdGen -> StdGen;
-      vary b g :=
-        let
-          splitG : StdGen × StdGen := stdSplit g;
-        in if b (snd splitG) (fst splitG);
+      vary : Bool -> StdGen -> StdGen
+        | b g :=
+          let
+            splitG : StdGen × StdGen := stdSplit g;
+          in if b (snd splitG) (fst splitG);
       terminating
-      digitsParity : List Bool;
-      digitsParity := map (x in binaryDigits (abs n)) x Nat.== 0;
+      digitsParity : List Bool :=
+        map (x in binaryDigits (abs n))
+          x Nat.== 0;
     in for (rand := vary (n < 0) rand0) (b in digitsParity)
          vary b rand;
 

--- a/Test/QuickCheck/CoArbitrary.juvix
+++ b/Test/QuickCheck/CoArbitrary.juvix
@@ -13,46 +13,42 @@ import Stdlib.Data.Nat.Ord as Nat;
 type CoArbitrary (A : Type) (B : Type) :=
   | coarbitrary : (Gen B -> A -> Gen B) -> CoArbitrary A B;
 
-binaryDigits : Nat -> List Nat;
-binaryDigits n :=
-  let
-    terminating
-    go : Nat -> List Nat;
-    go n :=
-      if (n Nat.== 0) nil (Nat.mod n 2 :: go (Nat.div n 2));
-  in reverse (go n);
+binaryDigits : Nat -> List Nat
+  | n :=
+    let
+      terminating
+      go : Nat -> List Nat;
+      go n :=
+        if (n Nat.== 0) nil (Nat.mod n 2 :: go (Nat.div n 2));
+    in reverse (go n);
 
-perturb : Int -> StdGen -> StdGen;
-perturb n rand0 :=
-  let
-    vary : Bool -> StdGen -> StdGen;
-    vary b g :=
-      let
-        splitG : StdGen × StdGen := stdSplit g;
-      in if b (snd splitG) (fst splitG);
-    terminating
-    digitsParity : List Bool;
-    digitsParity := map (x in binaryDigits (abs n)) x Nat.== 0;
-  in for (rand := vary (n < 0) rand0) (b in digitsParity)
-       vary b rand;
+perturb : Int -> StdGen -> StdGen
+  | n rand0 :=
+    let
+      vary : Bool -> StdGen -> StdGen;
+      vary b g :=
+        let
+          splitG : StdGen × StdGen := stdSplit g;
+        in if b (snd splitG) (fst splitG);
+      terminating
+      digitsParity : List Bool;
+      digitsParity := map (x in binaryDigits (abs n)) x Nat.== 0;
+    in for (rand := vary (n < 0) rand0) (b in digitsParity)
+         vary b rand;
 
-coarbitraryIntInt : CoArbitrary Int Int;
-coarbitraryIntInt :=
+coarbitraryIntInt : CoArbitrary Int Int :=
   coarbitrary
     \ {g n := gen \ {rand := runGen g (perturb n rand)}};
 
-coarbitraryIntIntHof : CoArbitrary Int (Int -> Int);
-coarbitraryIntIntHof :=
+coarbitraryIntIntHof : CoArbitrary Int (Int -> Int) :=
   coarbitrary
     \ {g n := gen \ {rand := runGen g (perturb n rand)}};
 
-coarbitraryIntBool : CoArbitrary Int Bool;
-coarbitraryIntBool :=
+coarbitraryIntBool : CoArbitrary Int Bool :=
   coarbitrary
     \ {g n := gen \ {rand := runGen g (perturb n rand)}};
 
-coarbitraryListInt : CoArbitrary (List Int) Int;
-coarbitraryListInt :=
+coarbitraryListInt : CoArbitrary (List Int) Int :=
   coarbitrary
     \ {g xs :=
       gen

--- a/Test/QuickCheck/CoArbitrary.juvix
+++ b/Test/QuickCheck/CoArbitrary.juvix
@@ -10,8 +10,9 @@ import Stdlib.Data.Nat as Nat;
 import Stdlib.Data.Nat.Ord as Nat;
 
 -- | A perturbation of a generator associated with a type B
+trait
 type CoArbitrary (A : Type) (B : Type) :=
-  | coarbitrary : (Gen B -> A -> Gen B) -> CoArbitrary A B;
+  mkCoarbitrary {coarbitrary : Gen B -> A -> Gen B};
 
 binaryDigits : Nat -> List Nat
   | n :=
@@ -37,20 +38,23 @@ perturb : Int -> StdGen -> StdGen
     in for (rand := vary (n < 0) rand0) (b in digitsParity)
          vary b rand;
 
+instance
 coarbitraryIntInt : CoArbitrary Int Int :=
-  coarbitrary
-    \ {g n := gen \ {rand := runGen g (perturb n rand)}};
+  mkCoarbitrary
+    \ {g n := mkGen \ {rand := Gen.run g (perturb n rand)}};
 
 coarbitraryIntIntHof : CoArbitrary Int (Int -> Int) :=
-  coarbitrary
-    \ {g n := gen \ {rand := runGen g (perturb n rand)}};
+  mkCoarbitrary
+    \ {g n := mkGen \ {rand := Gen.run g (perturb n rand)}};
 
+instance
 coarbitraryIntBool : CoArbitrary Int Bool :=
-  coarbitrary
-    \ {g n := gen \ {rand := runGen g (perturb n rand)}};
+  mkCoarbitrary
+    \ {g n := mkGen \ {rand := Gen.run g (perturb n rand)}};
 
+instance
 coarbitraryListInt : CoArbitrary (List Int) Int :=
-  coarbitrary
+  mkCoarbitrary
     \ {g xs :=
-      gen
-        \ {rand := runGen g (foldr perturb (perturb 0 rand) xs)}};
+      mkGen
+        \ {rand := Gen.run g (foldr perturb (perturb 0 rand) xs)}};

--- a/Test/QuickCheck/Fun.juvix
+++ b/Test/QuickCheck/Fun.juvix
@@ -1,0 +1,3 @@
+module Test.QuickCheck.Fun;
+
+type Fun A B := mkFun {fun : A -> B};

--- a/Test/QuickCheck/Gen.juvix
+++ b/Test/QuickCheck/Gen.juvix
@@ -6,9 +6,9 @@ import Data.Random open;
 type Gen (A : Type) :=
   | gen : (StdGen -> A) -> Gen A;
 
-runGen : {A : Type} -> Gen A -> StdGen -> A;
-runGen (gen f) := f;
+runGen : {A : Type} -> Gen A -> StdGen -> A
+  | (gen f) := f;
 
-promote :
-  {A : Type} -> {B : Type} -> (A -> Gen B) -> Gen (A -> B);
-promote f := gen \ {rand a := runGen (f a) rand};
+promote
+  : {A : Type} -> {B : Type} -> (A -> Gen B) -> Gen (A -> B)
+  | f := gen \ {rand a := runGen (f a) rand};

--- a/Test/QuickCheck/Gen.juvix
+++ b/Test/QuickCheck/Gen.juvix
@@ -3,12 +3,7 @@ module Test.QuickCheck.Gen;
 import Data.Random open;
 
 --- A generator of values of type A
-type Gen (A : Type) :=
-  | gen : (StdGen -> A) -> Gen A;
+type Gen (A : Type) := mkGen {run : StdGen -> A};
 
-runGen : {A : Type} -> Gen A -> StdGen -> A
-  | (gen f) := f;
-
-promote
-  : {A : Type} -> {B : Type} -> (A -> Gen B) -> Gen (A -> B)
-  | f := gen \ {rand a := runGen (f a) rand};
+promote {A B} (f : A -> Gen B) : Gen (A -> B) :=
+  mkGen \ {rand a := Gen.run (f a) rand};

--- a/Test/QuickCheck/Gen.juvix
+++ b/Test/QuickCheck/Gen.juvix
@@ -1,9 +1,16 @@
 module Test.QuickCheck.Gen;
 
 import Data.Random open;
+import Test.QuickCheck.Fun open;
 
 --- A generator of values of type A
 type Gen (A : Type) := mkGen {run : StdGen -> A};
 
 promote {A B} (f : A -> Gen B) : Gen (A -> B) :=
   mkGen \ {rand a := Gen.run (f a) rand};
+
+funGen {A B} (g : Gen (A -> B)) : Gen (Fun A B) :=
+  mkGen \ {rand := mkFun (Gen.run g rand)};
+
+promoteFun {A B} (f : A -> Gen B) : Gen (Fun A B) :=
+  funGen (promote f);

--- a/Test/QuickCheck/Property.juvix
+++ b/Test/QuickCheck/Property.juvix
@@ -9,5 +9,5 @@ import Test.QuickCheck.Result open;
 type Property :=
   | property : Gen Result -> Property;
 
-runProp : Property -> StdGen -> Result;
-runProp (property g) rand := runGen g rand;
+runProp : Property -> StdGen -> Result
+  | (property g) rand := runGen g rand;

--- a/Test/QuickCheck/Property.juvix
+++ b/Test/QuickCheck/Property.juvix
@@ -6,8 +6,7 @@ import Test.QuickCheck.Result open;
 
 --- A testable predicate from which we can obtain a ;Gen
   Result;
-type Property :=
-  | property : Gen Result -> Property;
+type Property := mkProperty {getGen : Gen Result};
 
-runProp : Property -> StdGen -> Result
-  | (property g) rand := runGen g rand;
+runProp (p : Property) (rand : StdGen) : Result :=
+  Gen.run (Property.getGen p) rand;

--- a/Test/QuickCheck/Result.juvix
+++ b/Test/QuickCheck/Result.juvix
@@ -11,22 +11,21 @@ type Result :=
   | success : Result
   | fail : Failure -> Result;
 
-isSuccess : Result -> Bool;
-isSuccess success := true;
-isSuccess (fail _) := false;
+isSuccess : Result -> Bool
+  | success := true
+  | (fail _) := false;
 
-showResult : Result -> String;
-showResult success := "success";
-showResult (fail (failure seed cs)) :=
-  "failure "
-    ++str "(seed : "
-    ++str natToString seed
-    ++str " , counterExamples: "
-    ++str ("[" ++str intercalate ", " cs ++str "]")
-    ++str ")";
+showResult : Result -> String
+  | success := "success"
+  | (fail (failure seed cs)) :=
+    "failure "
+      ++str "(seed : "
+      ++str natToString seed
+      ++str " , counterExamples: "
+      ++str ("[" ++str intercalate ", " cs ++str "]")
+      ++str ")";
 
-monoidResult : Monoid Result;
-monoidResult :=
+monoidResult : Monoid Result :=
   monoid
     success
     \ {
@@ -34,9 +33,9 @@ monoidResult :=
       | _ y := y
     };
 
-overFailure : Result -> (Failure -> Failure) -> Result;
-overFailure success _ := success;
-overFailure (fail x) f := fail (f x);
+overFailure : Result -> (Failure -> Failure) -> Result
+  | success _ := success
+  | (fail x) f := fail (f x);
 
-allSuccess : List Result -> Bool;
-allSuccess := isSuccess ∘ foldMap monoidResult id;
+allSuccess : List Result -> Bool :=
+  isSuccess ∘ foldMap monoidResult id;

--- a/Test/QuickCheck/Result.juvix
+++ b/Test/QuickCheck/Result.juvix
@@ -4,8 +4,7 @@ import Stdlib.Prelude open;
 import Data.Monoid open;
 import Data.String open;
 
-type Failure :=
-  | failure : Nat -> List String -> Failure;
+type Failure := failure : Nat -> List String -> Failure;
 
 type Result :=
   | success : Result

--- a/Test/QuickCheck/Testable.juvix
+++ b/Test/QuickCheck/Testable.juvix
@@ -12,41 +12,38 @@ import Test.QuickCheck.Gen open;
 type Testable (A : Type) :=
   | testable : (A -> Property) -> Testable A;
 
-toProp : {A : Type} -> Testable A -> A -> Property;
-toProp (testable f) := f;
+toProp : {A : Type} -> Testable A -> A -> Property
+  | (testable f) := f;
 
-forAll :
-  {A : Type}
+forAll
+  : {A : Type}
     -> {T : Type}
     -> Show A
     -> Testable T
     -> Gen A
     -> (A -> T)
-    -> Property;
-forAll {A} {T} (mkShow to-str) (testable asProp) g prop :=
-  property
-    (gen
-      \ {rand :=
-        let
-          srand : StdGen × StdGen := stdSplit rand;
-          rand1 : StdGen := fst srand;
-          rand2 : StdGen := snd srand;
-          arg : A := runGen g rand1;
-          subProp : Property := asProp (prop arg);
-          res : Result := runProp subProp rand2;
-        in overFailure
-          res
-          \ {(failure s cs) := failure s (to-str arg :: cs)}});
+    -> Property
+  | {A} {T} (mkShow to-str) (testable asProp) g prop :=
+    property
+      (gen
+        \ {rand :=
+          let
+            srand : StdGen × StdGen := stdSplit rand;
+            rand1 : StdGen := fst srand;
+            rand2 : StdGen := snd srand;
+            arg : A := runGen g rand1;
+            subProp : Property := asProp (prop arg);
+            res : Result := runProp subProp rand2;
+          in overFailure
+            res
+            \ {(failure s cs) := failure s (to-str arg :: cs)}});
 
-testableProperty : Testable Property;
-testableProperty := testable id;
+testableProperty : Testable Property := testable id;
 
-testableResult : Testable Result;
-testableResult :=
+testableResult : Testable Result :=
   testable \ {r := property (gen (const r))};
 
-testableBool : Testable Bool;
-testableBool :=
+testableBool : Testable Bool :=
   let
     toResult : Bool -> Result;
     toResult b := if b success (fail (failure 0 nil));
@@ -55,105 +52,93 @@ testableBool :=
 type Argument (A : Type) :=
   | argument : Show A -> Arbitrary A -> Argument A;
 
-testableFunction :
-  {A : Type}
+testableFunction
+  : {A : Type}
     -> {T : Type}
     -> Argument A
     -> Testable T
-    -> Testable (A -> T);
-testableFunction (argument s (arbitrary g)) t :=
-  testable \ {f := forAll s t g f};
+    -> Testable (A -> T)
+  | (argument s (arbitrary g)) t :=
+    testable \ {f := forAll s t g f};
 
-argumentInt : Argument Int;
-argumentInt := argument IntTraits.Show arbitraryInt;
+argumentInt : Argument Int :=
+  argument IntTraits.Show arbitraryInt;
 
-argumentNat : Argument Nat;
-argumentNat := argument NatTraits.Show arbitraryNat;
+argumentNat : Argument Nat :=
+  argument NatTraits.Show arbitraryNat;
 
-argumentList :
-  {A : Type} -> Argument A -> Argument (List A);
-argumentList (argument s a) :=
-  argument (ListTraits.Show s) (arbitraryList a);
+argumentList : {A : Type} -> Argument A -> Argument (List A)
+  | (argument s a) :=
+    argument (ListTraits.Show s) (arbitraryList a);
 
-showableFunction : {A B : Type} -> Show (A -> B);
-showableFunction := mkShow (const "function");
+showableFunction : {A B : Type} -> Show (A -> B) :=
+  mkShow (const "function");
 
-argumentListInt : Argument (List Int);
-argumentListInt := argumentList argumentInt;
+argumentListInt : Argument (List Int) :=
+  argumentList argumentInt;
 
-argumentFunction :
-  {A : Type}
+argumentFunction
+  : {A : Type}
     -> {B : Type}
     -> CoArbitrary A B
     -> Arbitrary B
-    -> Argument (A -> B);
-argumentFunction coArb arb :=
-  argument showableFunction (arbitraryFunction coArb arb);
+    -> Argument (A -> B)
+  | coArb arb :=
+    argument showableFunction (arbitraryFunction coArb arb);
 
-argumentIntInt : Argument (Int -> Int);
-argumentIntInt :=
+argumentIntInt : Argument (Int -> Int) :=
   argumentFunction coarbitraryIntInt arbitraryInt;
 
-argumentIntIntInt : Argument (Int -> Int -> Int);
-argumentIntIntInt :=
+argumentIntIntInt : Argument (Int -> Int -> Int) :=
   case argumentIntInt
     | argument _ arbIntInt :=
       argumentFunction coarbitraryIntIntHof arbIntInt;
 
-testableBinaryInt : Testable (Int -> Int -> Bool);
-testableBinaryInt :=
+testableBinaryInt : Testable (Int -> Int -> Bool) :=
   testableFunction
     argumentInt
     (testableFunction argumentInt testableBool);
 
-testableListInt : Testable (List Int -> Bool);
-testableListInt :=
+testableListInt : Testable (List Int -> Bool) :=
   testableFunction (argumentList argumentInt) testableBool;
 
-testableListIntListInt :
-  Testable (List Int -> List Int -> Bool);
-testableListIntListInt :=
+testableListIntListInt
+  : Testable (List Int -> List Int -> Bool) :=
   testableFunction
     (argumentList argumentInt)
     testableListInt;
 
-testableNatListInt : Testable (Nat -> List Int -> Bool);
-testableNatListInt :=
+testableNatListInt : Testable (Nat -> List Int -> Bool) :=
   testableFunction argumentNat testableListInt;
 
-testableHofIntBool : Testable ((Int -> Bool) -> Bool);
-testableHofIntBool :=
+testableHofIntBool : Testable ((Int -> Bool) -> Bool) :=
   let
     arg : Argument (Int -> Bool);
     arg := argumentFunction coarbitraryIntBool arbitraryBool;
   in testableFunction arg testableBool;
 
-testableListIntHofIntBool :
-  Testable (List Int -> (Int -> Bool) -> Bool);
-testableListIntHofIntBool :=
+testableListIntHofIntBool
+  : Testable (List Int -> (Int -> Bool) -> Bool) :=
   testableFunction
     (argumentList (argumentInt))
     testableHofIntBool;
 
-testableHofIntInt : Testable ((Int -> Int) -> Bool);
-testableHofIntInt :=
+testableHofIntInt : Testable ((Int -> Int) -> Bool) :=
   let
     arg :
       Argument (Int -> Int) :=
         argumentFunction coarbitraryIntInt arbitraryInt;
   in testableFunction arg testableBool;
 
-testableIntIntHofIntInt :
-  Testable (Int -> Int -> (Int -> Int) -> Bool);
-testableIntIntHofIntInt :=
+testableIntIntHofIntInt
+  : Testable (Int -> Int -> (Int -> Int) -> Bool) :=
   testableFunction
     argumentInt
     (testableFunction argumentInt testableHofIntInt);
 
-testableHofIntIntListIntListInt :
-  Testable
-    ((Int -> Int -> Int) -> List Int -> List Int -> Bool);
-testableHofIntIntListIntListInt :=
+testableHofIntIntListIntListInt
+  : Testable
+    ((Int -> Int -> Int) -> List Int -> List Int -> Bool) :=
   testableFunction
     argumentIntIntInt
     (testableFunction

--- a/Test/QuickCheck/Testable.juvix
+++ b/Test/QuickCheck/Testable.juvix
@@ -45,8 +45,8 @@ testableResult : Testable Result :=
 
 testableBool : Testable Bool :=
   let
-    toResult : Bool -> Result;
-    toResult b := if b success (fail (failure 0 nil));
+    toResult : Bool -> Result
+      | b := if b success (fail (failure 0 nil));
   in testable \ {b := toProp testableResult (toResult b)};
 
 type Argument (A : Type) :=
@@ -113,8 +113,8 @@ testableNatListInt : Testable (Nat -> List Int -> Bool) :=
 
 testableHofIntBool : Testable ((Int -> Bool) -> Bool) :=
   let
-    arg : Argument (Int -> Bool);
-    arg := argumentFunction coarbitraryIntBool arbitraryBool;
+    arg : Argument (Int -> Bool) :=
+      argumentFunction coarbitraryIntBool arbitraryBool;
   in testableFunction arg testableBool;
 
 testableListIntHofIntBool
@@ -125,9 +125,8 @@ testableListIntHofIntBool
 
 testableHofIntInt : Testable ((Int -> Int) -> Bool) :=
   let
-    arg :
-      Argument (Int -> Int) :=
-        argumentFunction coarbitraryIntInt arbitraryInt;
+    arg : Argument (Int -> Int) :=
+      argumentFunction coarbitraryIntInt arbitraryInt;
   in testableFunction arg testableBool;
 
 testableIntIntHofIntInt

--- a/Test/QuickCheck/Testable.juvix
+++ b/Test/QuickCheck/Testable.juvix
@@ -11,136 +11,64 @@ import Test.QuickCheck.Gen open;
 --- A conversion from a Type A to a ;Property;
 trait
 type Testable (A : Type) :=
-  mkTestable { testable : A -> Property };
+  mkTestable {toProp : A -> Property};
 
-toProp : {A : Type} -> Testable A -> A -> Property
-  | (mkTestable f) := f;
-
-forAll
-  : {A : Type}
-    -> {T : Type}
-    -> {{Show A}}
-    -> {{Testable T}}
-    -> Gen A
-    -> (A -> T)
-    -> Property
-  | {A} {T} g prop :=
-    property
-      (gen
+forAll {A T : Type} {{Show A}} {{Testable T}}
+  : Gen A -> (A -> T) -> Property
+  | g prop :=
+    mkProperty
+      (mkGen
         \ {rand :=
           let
             srand : StdGen × StdGen := stdSplit rand;
             rand1 : StdGen := fst srand;
             rand2 : StdGen := snd srand;
-            arg : A := runGen g rand1;
-            subProp : Property := Testable.testable (prop arg);
+            arg : A := Gen.run g rand1;
+            subProp : Property := Testable.toProp (prop arg);
             res : Result := runProp subProp rand2;
           in overFailure
             res
             \ {(failure s cs) := failure s (Show.show arg :: cs)}});
 
+instance
 testableProperty : Testable Property := mkTestable id;
 
+instance
 testableResult : Testable Result :=
-  mkTestable \ {r := property (gen (const r))};
+  mkTestable \ {r := mkProperty (mkGen (const r))};
 
+instance
 testableBool : Testable Bool :=
   let
     toResult : Bool -> Result
       | b := if b success (fail (failure 0 nil));
-  in mkTestable \ {b := toProp testableResult (toResult b)};
+  in mkTestable \ {b := Testable.toProp (toResult b)};
 
-type Argument (A : Type) :=
-  | argument : Show A -> Arbitrary A -> Argument A;
+testableFunction {A T} {{Show A}} {{Arbitrary A}} {{Testable
+  T}} : Testable (A -> T) :=
+  mkTestable \ {f := forAll Arbitrary.gen f};
 
-testableFunction
-  : {A : Type}
-    -> {T : Type}
-    -> Argument A
-    -> Testable T
-    -> Testable (A -> T)
-  | (argument s (arbitrary g)) t :=
-    mkTestable \ {f := forAll {{s}} {{t}} g f};
+testableFunction' {A T} {{Testable T}} {{Show
+  A}} {{Arbitrary A}} : Testable (A -> T) := testableFunction;
 
-argumentInt : Argument Int :=
-  argument showIntI arbitraryInt;
+testableFunction2 {A B C} {{Arbitrary A}} {{Show
+  A}} {{Arbitrary B}} {{Show B}} {{Testable C}}
+  : Testable (A -> B -> C) :=
+  testableFunction' {{testableFunction}};
 
-argumentNat : Argument Nat :=
-  argument showNatI arbitraryNat;
+testableHof1 {A B C D} {{Show A}} {{Arbitrary A}} {{Testable
+  D}} {{Arbitrary C}} {{CoArbitrary B C}}
+  : Testable (A -> (B -> C) -> D) :=
+  testableFunction'
+    {{testableFunction
+      {{showableFunction}}
+      {{arbitraryFunction}}}};
 
-argumentList : {A : Type} -> Argument A -> Argument (List A)
-  | (argument s a) :=
-    argument (showListI {{s}}) (arbitraryList a);
+testableHof2 {A B C D E} {{Show A}} {{Arbitrary A}} {{Show
+  B}} {{Arbitrary B}} {{Testable E}} {{Arbitrary
+  D}} {{CoArbitrary C D}}
+  : Testable (A -> B -> (C -> D) -> E) :=
+  testableFunction' {{testableHof1}};
 
-showableFunction : {A B : Type} -> Show (A -> B) :=
+showableFunction {A B : Type} : Show (A -> B) :=
   mkShow (const "function");
-
-argumentListInt : Argument (List Int) :=
-  argumentList argumentInt;
-
-argumentFunction
-  : {A : Type}
-    -> {B : Type}
-    -> CoArbitrary A B
-    -> Arbitrary B
-    -> Argument (A -> B)
-  | coArb arb :=
-    argument showableFunction (arbitraryFunction coArb arb);
-
-argumentIntInt : Argument (Int -> Int) :=
-  argumentFunction coarbitraryIntInt arbitraryInt;
-
-argumentIntIntInt : Argument (Int -> Int -> Int) :=
-  case argumentIntInt
-    | argument _ arbIntInt :=
-      argumentFunction coarbitraryIntIntHof arbIntInt;
-
-testableBinaryInt : Testable (Int -> Int -> Bool) :=
-  testableFunction
-    argumentInt
-    (testableFunction argumentInt testableBool);
-
-testableListInt : Testable (List Int -> Bool) :=
-  testableFunction (argumentList argumentInt) testableBool;
-
-testableListIntListInt
-  : Testable (List Int -> List Int -> Bool) :=
-  testableFunction
-    (argumentList argumentInt)
-    testableListInt;
-
-testableNatListInt : Testable (Nat -> List Int -> Bool) :=
-  testableFunction argumentNat testableListInt;
-
-testableHofIntBool : Testable ((Int -> Bool) -> Bool) :=
-  let
-    arg : Argument (Int -> Bool) :=
-      argumentFunction coarbitraryIntBool arbitraryBool;
-  in testableFunction arg testableBool;
-
-testableListIntHofIntBool
-  : Testable (List Int -> (Int -> Bool) -> Bool) :=
-  testableFunction
-    (argumentList (argumentInt))
-    testableHofIntBool;
-
-testableHofIntInt : Testable ((Int -> Int) -> Bool) :=
-  let
-    arg : Argument (Int -> Int) :=
-      argumentFunction coarbitraryIntInt arbitraryInt;
-  in testableFunction arg testableBool;
-
-testableIntIntHofIntInt
-  : Testable (Int -> Int -> (Int -> Int) -> Bool) :=
-  testableFunction
-    argumentInt
-    (testableFunction argumentInt testableHofIntInt);
-
-testableHofIntIntListIntListInt
-  : Testable
-    ((Int -> Int -> Int) -> List Int -> List Int -> Bool) :=
-  testableFunction
-    argumentIntIntInt
-    (testableFunction
-      argumentListInt
-      (testableFunction argumentListInt testableBool));

--- a/Test/QuickCheck/Testable.juvix
+++ b/Test/QuickCheck/Testable.juvix
@@ -9,21 +9,22 @@ import Test.QuickCheck.Property open;
 import Test.QuickCheck.Gen open;
 
 --- A conversion from a Type A to a ;Property;
+trait
 type Testable (A : Type) :=
-  | testable : (A -> Property) -> Testable A;
+  mkTestable { testable : A -> Property };
 
 toProp : {A : Type} -> Testable A -> A -> Property
-  | (testable f) := f;
+  | (mkTestable f) := f;
 
 forAll
   : {A : Type}
     -> {T : Type}
-    -> Show A
-    -> Testable T
+    -> {{Show A}}
+    -> {{Testable T}}
     -> Gen A
     -> (A -> T)
     -> Property
-  | {A} {T} (mkShow to-str) (testable asProp) g prop :=
+  | {A} {T} g prop :=
     property
       (gen
         \ {rand :=
@@ -32,22 +33,22 @@ forAll
             rand1 : StdGen := fst srand;
             rand2 : StdGen := snd srand;
             arg : A := runGen g rand1;
-            subProp : Property := asProp (prop arg);
+            subProp : Property := Testable.testable (prop arg);
             res : Result := runProp subProp rand2;
           in overFailure
             res
-            \ {(failure s cs) := failure s (to-str arg :: cs)}});
+            \ {(failure s cs) := failure s (Show.show arg :: cs)}});
 
-testableProperty : Testable Property := testable id;
+testableProperty : Testable Property := mkTestable id;
 
 testableResult : Testable Result :=
-  testable \ {r := property (gen (const r))};
+  mkTestable \ {r := property (gen (const r))};
 
 testableBool : Testable Bool :=
   let
     toResult : Bool -> Result
       | b := if b success (fail (failure 0 nil));
-  in testable \ {b := toProp testableResult (toResult b)};
+  in mkTestable \ {b := toProp testableResult (toResult b)};
 
 type Argument (A : Type) :=
   | argument : Show A -> Arbitrary A -> Argument A;
@@ -59,7 +60,7 @@ testableFunction
     -> Testable T
     -> Testable (A -> T)
   | (argument s (arbitrary g)) t :=
-    testable \ {f := forAll s t g f};
+    mkTestable \ {f := forAll {{s}} {{t}} g f};
 
 argumentInt : Argument Int :=
   argument showIntI arbitraryInt;

--- a/Test/QuickCheck/Testable.juvix
+++ b/Test/QuickCheck/Testable.juvix
@@ -62,14 +62,14 @@ testableFunction
     testable \ {f := forAll s t g f};
 
 argumentInt : Argument Int :=
-  argument IntTraits.Show arbitraryInt;
+  argument showIntI arbitraryInt;
 
 argumentNat : Argument Nat :=
-  argument NatTraits.Show arbitraryNat;
+  argument showNatI arbitraryNat;
 
 argumentList : {A : Type} -> Argument A -> Argument (List A)
   | (argument s a) :=
-    argument (ListTraits.Show s) (arbitraryList a);
+    argument (showListI {{s}}) (arbitraryList a);
 
 showableFunction : {A B : Type} -> Show (A -> B) :=
   mkShow (const "function");

--- a/Test/QuickCheck/Testable.juvix
+++ b/Test/QuickCheck/Testable.juvix
@@ -7,6 +7,7 @@ import Test.QuickCheck.CoArbitrary open;
 import Test.QuickCheck.Result open;
 import Test.QuickCheck.Property open;
 import Test.QuickCheck.Gen open;
+import Test.QuickCheck.Fun open;
 
 --- A conversion from a Type A to a ;Property;
 trait
@@ -44,31 +45,13 @@ testableBool : Testable Bool :=
       | b := if b success (fail (failure 0 nil));
   in mkTestable \ {b := Testable.toProp (toResult b)};
 
+-- Instance uses Fun wrapper because Testable (A -> T) is not currently supported by the compiler.
+-- https://github.com/anoma/juvix/issues/2371
+instance
 testableFunction {A T} {{Show A}} {{Arbitrary A}} {{Testable
-  T}} : Testable (A -> T) :=
-  mkTestable \ {f := forAll Arbitrary.gen f};
+  T}} : Testable (Fun A T) :=
+  mkTestable \ {f := forAll Arbitrary.gen (Fun.fun f)};
 
-testableFunction' {A T} {{Testable T}} {{Show
-  A}} {{Arbitrary A}} : Testable (A -> T) := testableFunction;
-
-testableFunction2 {A B C} {{Arbitrary A}} {{Show
-  A}} {{Arbitrary B}} {{Show B}} {{Testable C}}
-  : Testable (A -> B -> C) :=
-  testableFunction' {{testableFunction}};
-
-testableHof1 {A B C D} {{Show A}} {{Arbitrary A}} {{Testable
-  D}} {{Arbitrary C}} {{CoArbitrary B C}}
-  : Testable (A -> (B -> C) -> D) :=
-  testableFunction'
-    {{testableFunction
-      {{showableFunction}}
-      {{arbitraryFunction}}}};
-
-testableHof2 {A B C D E} {{Show A}} {{Arbitrary A}} {{Show
-  B}} {{Arbitrary B}} {{Testable E}} {{Arbitrary
-  D}} {{CoArbitrary C D}}
-  : Testable (A -> B -> (C -> D) -> E) :=
-  testableFunction' {{testableHof1}};
-
-showableFunction {A B : Type} : Show (A -> B) :=
+instance
+showableFunction {A B : Type} : Show (Fun A B) :=
   mkShow (const "function");

--- a/Test/QuickCheckTest.juvix
+++ b/Test/QuickCheckTest.juvix
@@ -11,49 +11,50 @@ import Stdlib.Debug.Fail as Fail;
 type Test :=
   | test : String -> Property -> Test;
 
-mkTest :
-  {Predicate : Type}
+mkTest
+  : {Predicate : Type}
     -> Testable Predicate
     -> String
     -> Predicate
-    -> Test;
-mkTest t name p := test name (toProp t p);
+    -> Test
+  | t name p := test name (toProp t p);
 
 type TestResult :=
   | testResult : String -> Result -> TestResult;
 
-result : TestResult -> Result;
-result (testResult _ r) := r;
+result : TestResult -> Result
+  | (testResult _ r) := r;
 
-allTestSuccess : List TestResult -> Bool;
-allTestSuccess ts := allSuccess (map result ts);
+allTestSuccess : List TestResult -> Bool
+  | ts := allSuccess (map result ts);
 
-showTestResult : TestResult -> String;
-showTestResult (testResult name res) :=
-  "'" ++str name ++str "': " ++str showResult res;
+showTestResult : TestResult -> String
+  | (testResult name res) :=
+    "'" ++str name ++str "': " ++str showResult res;
 
-runTest : Nat -> Nat -> Test -> TestResult;
-runTest attemptNum seed (test name p) :=
-  testResult
-    name
-    (quickcheck attemptNum seed testableProperty p);
+runTest : Nat -> Nat -> Test -> TestResult
+  | attemptNum seed (test name p) :=
+    testResult
+      name
+      (quickcheck attemptNum seed testableProperty p);
 
-runTests : Nat -> Nat -> List Test -> List TestResult;
-runTests attemptNum startSeed ts :=
-  let
-    numTests : Nat := length ts;
-    testSeeds : List Nat;
-    testSeeds :=
-      map (n in rangeStep attemptNum numTests) startSeed + n;
-  in zipWith (runTest attemptNum) testSeeds ts;
+runTests : Nat -> Nat -> List Test -> List TestResult
+  | attemptNum startSeed ts :=
+    let
+      numTests : Nat := length ts;
+      testSeeds : List Nat;
+      testSeeds :=
+        map (n in rangeStep attemptNum numTests)
+          startSeed + n;
+    in zipWith (runTest attemptNum) testSeeds ts;
 
-runTestsIO : Nat -> Nat -> List Test -> IO;
-runTestsIO attemptNum startSeed ts :=
-  let
-    results :
-      List TestResult := runTests attemptNum startSeed ts;
-  in printStringLn (lines (map showTestResult results))
-    >> if
-      (allTestSuccess results)
-      (printStringLn "All tests passed")
-      (Fail.fail "Test failed");
+runTestsIO : Nat -> Nat -> List Test -> IO
+  | attemptNum startSeed ts :=
+    let
+      results :
+        List TestResult := runTests attemptNum startSeed ts;
+    in printStringLn (lines (map showTestResult results))
+      >> if
+        (allTestSuccess results)
+        (printStringLn "All tests passed")
+        (Fail.fail "Test failed");

--- a/Test/QuickCheckTest.juvix
+++ b/Test/QuickCheckTest.juvix
@@ -42,8 +42,7 @@ runTests : Nat -> Nat -> List Test -> List TestResult
   | attemptNum startSeed ts :=
     let
       numTests : Nat := length ts;
-      testSeeds : List Nat;
-      testSeeds :=
+      testSeeds : List Nat :=
         map (n in rangeStep attemptNum numTests)
           startSeed + n;
     in zipWith (runTest attemptNum) testSeeds ts;
@@ -51,8 +50,8 @@ runTests : Nat -> Nat -> List Test -> List TestResult
 runTestsIO : Nat -> Nat -> List Test -> IO
   | attemptNum startSeed ts :=
     let
-      results :
-        List TestResult := runTests attemptNum startSeed ts;
+      results : List TestResult :=
+        runTests attemptNum startSeed ts;
     in printStringLn (lines (map showTestResult results))
       >> if
         (allTestSuccess results)

--- a/Test/QuickCheckTest.juvix
+++ b/Test/QuickCheckTest.juvix
@@ -9,34 +9,33 @@ import Stdlib.Debug.Fail as Fail;
 
 -- | The data defining a QuickCheck test
 type Test :=
-  | test : String -> Property -> Test;
+  test {
+    name : String;
+    property : Property
+  };
 
-mkTest
-  : {Predicate : Type}
-    -> Testable Predicate
-    -> String
-    -> Predicate
-    -> Test
-  | t name p := test name (toProp t p);
+mkTest {Predicate : Type} {{Testable
+  Predicate}} (name : String) (predicate : Predicate)
+  : Test := test name (Testable.toProp predicate);
 
 type TestResult :=
-  | testResult : String -> Result -> TestResult;
+  testResult {
+    name : String;
+    result : Result
+  };
 
-result : TestResult -> Result
-  | (testResult _ r) := r;
+allTestSuccess (ts : List TestResult) : Bool :=
+  allSuccess (map TestResult.result ts);
 
-allTestSuccess : List TestResult -> Bool
-  | ts := allSuccess (map result ts);
-
-showTestResult : TestResult -> String
-  | (testResult name res) :=
-    "'" ++str name ++str "': " ++str showResult res;
+showTestResult (result : TestResult) : String :=
+  "'"
+    ++str TestResult.name result
+    ++str "': "
+    ++str showResult (TestResult.result result);
 
 runTest : Nat -> Nat -> Test -> TestResult
   | attemptNum seed (test name p) :=
-    testResult
-      name
-      (quickcheck attemptNum seed testableProperty p);
+    testResult name (quickcheck attemptNum seed p);
 
 runTests : Nat -> Nat -> List Test -> List TestResult
   | attemptNum startSeed ts :=

--- a/juvix.yaml
+++ b/juvix.yaml
@@ -5,4 +5,4 @@ dependencies:
   - git:
       url: https://github.com/anoma/juvix-stdlib
       name: stdlib
-      ref: 8d3941afdae706fe1c9960e7b68be799df515c32
+      ref: 4facf14d9b2d06b81ce1be1882aa9050f768cb45

--- a/juvix.yaml
+++ b/juvix.yaml
@@ -1,4 +1,8 @@
 name: quickcheck
-version: 0.6.2
+version: 0.7.0
+main: Example.juvix
 dependencies:
-  - deps/stdlib
+  - git:
+      url: https://github.com/anoma/juvix-stdlib
+      name: stdlib
+      ref: 8d3941afdae706fe1c9960e7b68be799df515c32


### PR DESCRIPTION
This PR updates the library for 0.5.0 syntax and makes API changes that take advantage of trait resolution.

`Testable` and `Arbitrary` and `CoArbitrary` are now `traits`.

We cannot define instances like `Testable (A -> B)` yet, so for most properties we need to pass in the trait instances explicitly.

To help with this we write functions like the following:

```
testableHof1 {A B C D} {{Show A}} {{Arbitrary A}} {{Testable D}} {{Arbitrary C}} {{CoArbitrary B C}} : Testable (A -> (B -> C) -> D)
```

which uses the trait resolution to facilitate things to some extent.

* Closes https://github.com/anoma/juvix-quickcheck/pull/6