### PR TITLE
Use defaultStdlib

### DIFF
--- a/Package.juvix
+++ b/Package.juvix
@@ -6,6 +6,6 @@ package : Package :=
   defaultPackage@?{
     name := "quickcheck";
     version := mkVersion 0 16 0;
-    dependencies := [github "anoma" "juvix-stdlib" "v0.8.0"];
+    dependencies := [defaultStdlib];
     main := just "Example.juvix";
   };


### PR DESCRIPTION
Because we use quickcheck to test the default standard library included in the compiler, they need to match.